### PR TITLE
Update Boltx child id in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ children = [
 Now you can run query with the name you set
 
 ```elixir
-iex> Boltx.query!(Bolt, "return 1 as n") |> Boltx.Response.first()
+iex> Boltx.query!(Boltx, "return 1 as n") |> Boltx.Response.first()
 %{"n" => 1}
 ```
 


### PR DESCRIPTION
The child id is Boltx in application.ex

``` 
%{
    id: Boltx,
    start: {Boltx, :start_link, [Application.get_env(:boltx, Bolt)] },
}
```

So we need to use the same id in Boltx.query!/2 too.
```
Boltx.query!(Boltx, "return 1 as n") |> Boltx.Response.first()
```
