### PR TITLE
Temporary function support for Bolt v5

### DIFF
--- a/lib/boltx/pack_stream/markers.ex
+++ b/lib/boltx/pack_stream/markers.ex
@@ -81,12 +81,16 @@ defmodule Boltx.PackStream.Markers do
       @legacy_datetime_with_zone_offset_signature 0x46
       @legacy_datetime_with_zone_offset_struct_size 3
 
-      # Legacy Datetime with TZ offset
+      # Datetime with TZ offset
       @datetime_with_zone_offset_signature 0x49
       @datetime_with_zone_offset_struct_size 3
 
+      # Legacy Datetime with TZ id
+      @legacy_datetime_with_zone_id_signature 0x66
+      @legacy_datetime_with_zone_id_struct_size 3
+
       # Datetime with TZ id
-      @datetime_with_zone_id_signature 0x66
+      @datetime_with_zone_id_signature 0x69
       @datetime_with_zone_id_struct_size 3
 
       # Duration

--- a/lib/boltx/pack_stream/markers.ex
+++ b/lib/boltx/pack_stream/markers.ex
@@ -77,8 +77,12 @@ defmodule Boltx.PackStream.Markers do
       @local_datetime_signature 0x64
       @local_datetime_struct_size 2
 
-      # Datetime with TZ offset
-      @datetime_with_zone_offset_signature 0x46
+      # Legacy Datetime with TZ offset
+      @legacy_datetime_with_zone_offset_signature 0x46
+      @legacy_datetime_with_zone_offset_struct_size 3
+
+      # Legacy Datetime with TZ offset
+      @datetime_with_zone_offset_signature 0x49
       @datetime_with_zone_offset_struct_size 3
 
       # Datetime with TZ id

--- a/lib/boltx/pack_stream/packer.ex
+++ b/lib/boltx/pack_stream/packer.ex
@@ -252,8 +252,8 @@ defimpl Boltx.PackStream.Packer, for: Boltx.Types.DateTimeWithTZOffset do
       )
 
     [
-      <<@tiny_struct_marker::4, @datetime_with_zone_offset_struct_size::4,
-        @datetime_with_zone_offset_signature>>,
+      <<@tiny_struct_marker::4, @legacy_datetime_with_zone_offset_struct_size::4,
+        @legacy_datetime_with_zone_offset_signature>>,
       data
     ]
   end

--- a/lib/boltx/pack_stream/packer.ex
+++ b/lib/boltx/pack_stream/packer.ex
@@ -179,8 +179,8 @@ defimpl Boltx.PackStream.Packer, for: DateTime do
       )
 
     [
-      <<@tiny_struct_marker::4, @datetime_with_zone_id_struct_size::4,
-        @datetime_with_zone_id_signature>>,
+      <<@tiny_struct_marker::4, @legacy_datetime_with_zone_id_struct_size::4,
+        @legacy_datetime_with_zone_id_signature>>,
       data
     ]
   end

--- a/lib/boltx/pack_stream/unpacker.ex
+++ b/lib/boltx/pack_stream/unpacker.ex
@@ -231,6 +231,25 @@ defmodule Boltx.PackStream.Unpacker do
     [dt | rest]
   end
 
+  # Legacy Datetime with zone offset
+  def unpack(
+        {@legacy_datetime_with_zone_offset_signature, struct,
+         @legacy_datetime_with_zone_offset_struct_size}
+      ) do
+    {[seconds, nanoseconds, zone_offset], rest} =
+      decode_struct(struct, @datetime_with_zone_id_struct_size)
+
+    naive_dt =
+      NaiveDateTime.add(
+        ~N[1970-01-01 00:00:00.000000],
+        seconds * 1_000_000_000 + nanoseconds,
+        :nanosecond
+      )
+
+    dt = DateTimeWithTZOffset.create(naive_dt, zone_offset)
+    [dt | rest]
+  end
+
   # Datetime with zone offset
   def unpack(
         {@datetime_with_zone_offset_signature, struct, @datetime_with_zone_offset_struct_size}

--- a/lib/boltx/pack_stream/unpacker.ex
+++ b/lib/boltx/pack_stream/unpacker.ex
@@ -260,7 +260,7 @@ defmodule Boltx.PackStream.Unpacker do
     naive_dt =
       NaiveDateTime.add(
         ~N[1970-01-01 00:00:00.000000],
-        seconds * 1_000_000_000 + nanoseconds,
+        (seconds + zone_offset) * 1_000_000_000 + nanoseconds,
         :nanosecond
       )
 

--- a/test/boltx_test.exs
+++ b/test/boltx_test.exs
@@ -78,6 +78,31 @@ defmodule BoltxTest do
              "missing 'The Name Kote' database, or data incomplete"
     end
 
+    @tag :bolt_2_x
+    @tag :bolt_3_x
+    @tag :bolt_4_x
+    @tag :bolt_5_x
+    test "a query to get a Node with temporal functions", c do
+      uuid = "6152f30e-076a-4479-b575-764bf6ab5e38"
+      Boltx.query!(c.conn, "CREATE (user:User{uuid: $uuid, name: 'John', created_at: DATETIME()})", %{uuid: uuid})
+      response = Boltx.query!(c.conn, "MATCH (user:User {uuid: $uuid })RETURN user", %{uuid: uuid})
+
+      assert %Boltx.Response{
+        results: [
+          %{
+            "user" => %Boltx.Types.Node{
+              id: _,
+              properties: %{
+                "created_at" => _,
+                "name" => "John",
+                "uuid" => "6152f30e-076a-4479-b575-764bf6ab5e38"
+              }
+            }
+          }
+        ]
+      } = response
+    end
+
     @tag :core
     test "A procedure call failure should send reset and not lock the db" do
       opts = [pool_size: 1] ++ @opts

--- a/test/boltx_test.exs
+++ b/test/boltx_test.exs
@@ -2,7 +2,7 @@ defmodule BoltxTest do
   use ExUnit.Case, async: true
 
   alias Boltx.Response
-  alias Boltx.Types.{Duration, Point, DateTimeWithTZOffset}
+  alias Boltx.Types.{Duration, Point, DateTimeWithTZOffset, TimeWithTZOffset}
 
   @opts Boltx.TestHelper.opts()
 
@@ -92,7 +92,12 @@ defmodule BoltxTest do
           date_time_offset: DATETIME('2024-01-20T18:47:05.850000-06:00'),
           date_time: DATETIME('2000-01-01'),
           date_time2: DATETIME('2000-01-01T00:00:00Z'),
-          date_time_with_zona_id: DATETIME('2024-01-21T14:03:45.702000-08:00[America/Los_Angeles]')
+          date_time_with_zona_id: DATETIME('2024-01-21T14:03:45.702000-08:00[America/Los_Angeles]'),
+          date: DATE("2024-01-21"),
+          localtime: LOCALTIME("15:41:10.222000000"),
+          localdatetime: LOCALDATETIME("2024-01-21T15:41:40.706000000"),
+          time: TIME("15:41:10.222000000Z"),
+          time_with_offset: TIME("15:41:10.222000000-06:00")
         })
       """
 
@@ -111,6 +116,11 @@ defmodule BoltxTest do
                        "date_time" => date_time,
                        "date_time2" => date_time2,
                        "date_time_with_zona_id" => date_time_with_zona_id,
+                       "date" => date,
+                       "localtime" => localtime,
+                       "time" => time,
+                       "localdatetime" => localdatetime,
+                       "time_with_offset" => time_with_offset,
                        "name" => "John",
                        "uuid" => "6152f30e-076a-4479-b575-764bf6ab5e38"
                      }
@@ -130,6 +140,12 @@ defmodule BoltxTest do
 
       assert "2024-01-21 14:03:45.702000-08:00 PST America/Los_Angeles" ==
                DateTime.to_string(date_time_with_zona_id)
+
+      assert ~D[2024-01-21] == date
+      assert ~T[15:41:10.222000] == localtime
+      assert ~N[2024-01-21 15:41:40.706000] == localdatetime
+      assert {:ok, "15:41:10.222000+00:00"} == TimeWithTZOffset.format_param(time)
+      assert {:ok, "15:41:10.222000-06:00"} == TimeWithTZOffset.format_param(time_with_offset)
     end
 
     @tag :core

--- a/test/boltx_test.exs
+++ b/test/boltx_test.exs
@@ -2,7 +2,7 @@ defmodule BoltxTest do
   use ExUnit.Case, async: true
 
   alias Boltx.Response
-  alias Boltx.Types.{Duration, Point}
+  alias Boltx.Types.{Duration, Point, DateTimeWithTZOffset}
 
   @opts Boltx.TestHelper.opts()
 
@@ -89,7 +89,9 @@ defmodule BoltxTest do
         CREATE (user:User{
           uuid: $uuid,
           name: 'John',
-          date_time_with_tz_offset: DATETIME()
+          date_time_offset: DATETIME('2024-01-20T18:47:05.850000-06:00'),
+          date_time: DATETIME('2000-01-01'),
+          date_time2: DATETIME('2000-01-01T00:00:00Z')
         })
       """
 
@@ -104,7 +106,9 @@ defmodule BoltxTest do
                    "user" => %Boltx.Types.Node{
                      id: _,
                      properties: %{
-                       "date_time_with_tz_offset" => %Boltx.Types.DateTimeWithTZOffset{},
+                       "date_time_offset" => date_time_offset,
+                       "date_time" => date_time,
+                       "date_time2" => date_time2,
                        "name" => "John",
                        "uuid" => "6152f30e-076a-4479-b575-764bf6ab5e38"
                      }
@@ -112,6 +116,9 @@ defmodule BoltxTest do
                  }
                ]
              } = response
+      assert {:ok, "2024-01-20T18:47:05.850000-06:00"} == DateTimeWithTZOffset.format_param(date_time_offset)
+      assert {:ok, "2000-01-01T00:00:00.000000+00:00"} == DateTimeWithTZOffset.format_param(date_time)
+      assert {:ok, "2000-01-01T00:00:00.000000+00:00"} == DateTimeWithTZOffset.format_param(date_time2)
     end
 
     @tag :core

--- a/test/boltx_test.exs
+++ b/test/boltx_test.exs
@@ -84,23 +84,34 @@ defmodule BoltxTest do
     @tag :bolt_5_x
     test "a query to get a Node with temporal functions", c do
       uuid = "6152f30e-076a-4479-b575-764bf6ab5e38"
-      Boltx.query!(c.conn, "CREATE (user:User{uuid: $uuid, name: 'John', created_at: DATETIME()})", %{uuid: uuid})
-      response = Boltx.query!(c.conn, "MATCH (user:User {uuid: $uuid })RETURN user", %{uuid: uuid})
+
+      cypher_create = """
+        CREATE (user:User{
+          uuid: $uuid,
+          name: 'John',
+          date_time_with_tz_offset: DATETIME()
+        })
+      """
+
+      Boltx.query!(c.conn, cypher_create, %{uuid: uuid})
+
+      response =
+        Boltx.query!(c.conn, "MATCH (user:User {uuid: $uuid }) RETURN user", %{uuid: uuid})
 
       assert %Boltx.Response{
-        results: [
-          %{
-            "user" => %Boltx.Types.Node{
-              id: _,
-              properties: %{
-                "created_at" => _,
-                "name" => "John",
-                "uuid" => "6152f30e-076a-4479-b575-764bf6ab5e38"
-              }
-            }
-          }
-        ]
-      } = response
+               results: [
+                 %{
+                   "user" => %Boltx.Types.Node{
+                     id: _,
+                     properties: %{
+                       "date_time_with_tz_offset" => %Boltx.Types.DateTimeWithTZOffset{},
+                       "name" => "John",
+                       "uuid" => "6152f30e-076a-4479-b575-764bf6ab5e38"
+                     }
+                   }
+                 }
+               ]
+             } = response
     end
 
     @tag :core

--- a/test/boltx_test.exs
+++ b/test/boltx_test.exs
@@ -91,7 +91,8 @@ defmodule BoltxTest do
           name: 'John',
           date_time_offset: DATETIME('2024-01-20T18:47:05.850000-06:00'),
           date_time: DATETIME('2000-01-01'),
-          date_time2: DATETIME('2000-01-01T00:00:00Z')
+          date_time2: DATETIME('2000-01-01T00:00:00Z'),
+          date_time_with_zona_id: DATETIME('2024-01-21T14:03:45.702000-08:00[America/Los_Angeles]')
         })
       """
 
@@ -109,6 +110,7 @@ defmodule BoltxTest do
                        "date_time_offset" => date_time_offset,
                        "date_time" => date_time,
                        "date_time2" => date_time2,
+                       "date_time_with_zona_id" => date_time_with_zona_id,
                        "name" => "John",
                        "uuid" => "6152f30e-076a-4479-b575-764bf6ab5e38"
                      }
@@ -116,9 +118,18 @@ defmodule BoltxTest do
                  }
                ]
              } = response
-      assert {:ok, "2024-01-20T18:47:05.850000-06:00"} == DateTimeWithTZOffset.format_param(date_time_offset)
-      assert {:ok, "2000-01-01T00:00:00.000000+00:00"} == DateTimeWithTZOffset.format_param(date_time)
-      assert {:ok, "2000-01-01T00:00:00.000000+00:00"} == DateTimeWithTZOffset.format_param(date_time2)
+
+      assert {:ok, "2024-01-20T18:47:05.850000-06:00"} ==
+               DateTimeWithTZOffset.format_param(date_time_offset)
+
+      assert {:ok, "2000-01-01T00:00:00.000000+00:00"} ==
+               DateTimeWithTZOffset.format_param(date_time)
+
+      assert {:ok, "2000-01-01T00:00:00.000000+00:00"} ==
+               DateTimeWithTZOffset.format_param(date_time2)
+
+      assert "2024-01-21 14:03:45.702000-08:00 PST America/Los_Angeles" ==
+               DateTime.to_string(date_time_with_zona_id)
     end
 
     @tag :core


### PR DESCRIPTION
In the Bolt v5 version, two new temporary structures have been added.

1. Datetime structure is added to replace Legacy Datetime.
2. DateTimeZoneId structure is added and replaces Legacy DateTimeZoneId.

Driver clients will not notice the difference. The decoding is done to the structures: `DateTimeWithTZOffset` for Datetime and `TimeWithTZOffset` for DateTimeZoneId.

You can read more details about the changes to the structures here: [Legacy_structures](https://neo4j.com/docs/bolt/current/bolt/structure-semantics/#_legacy_structures)