### PR TITLE
Using extras in Query

### DIFF
--- a/lib/boltx.ex
+++ b/lib/boltx.ex
@@ -99,6 +99,17 @@ defmodule Boltx do
     DBConnection.child_spec(Boltx.Connection, options)
   end
 
+  @doc """
+  Executes a single query and returns the result.
+
+  ## Examples
+
+  ```elixir
+  {:ok, result} = Boltx.query(conn, "MATCH (n) RETURN n LIMIT 1")
+
+  {:ok, people} = Boltx.query(conn, "MATCH (n:PERSON) RETURN n", %{}, [db: "mydb"])
+  ```
+  """
   def query(conn, statement, params \\ %{}, opts \\ []) do
     formatted_params =
       params
@@ -106,12 +117,26 @@ defmodule Boltx do
       |> Enum.map(fn {k, {:ok, value}} -> {k, value} end)
       |> Map.new()
 
-    extra = Map.take(opts, [:bookmarks, :mode, :db, :tx_metadata])
+    extra = opts
+      |> Keyword.take([:bookmarks, :mode, :db, :tx_metadata])
+      |> Enum.into(%{}) # Convert to map
 
     query = %Boltx.Query{statement: statement, extra: extra}
+
     do_query(conn, query, formatted_params, opts)
   end
 
+  @doc """
+  Executes a single query and returns the result.
+
+  ## Examples
+
+  ```elixir
+  result = Boltx.query!(conn, "MATCH (n) RETURN n LIMIT 1")
+
+  people = Boltx.query!(conn, "MATCH (n:PERSON) RETURN n", %{}, [db: "mydb"])
+  ```
+  """
   def query!(conn, statement, params \\ %{}, opts \\ []) do
     case query(conn, statement, params, opts) do
       {:ok, result} -> result

--- a/lib/boltx.ex
+++ b/lib/boltx.ex
@@ -117,9 +117,11 @@ defmodule Boltx do
       |> Enum.map(fn {k, {:ok, value}} -> {k, value} end)
       |> Map.new()
 
-    extra = opts
+    extra =
+      opts
       |> Keyword.take([:bookmarks, :mode, :db, :tx_metadata])
-      |> Enum.into(%{}) # Convert to map
+      # Convert to map
+      |> Enum.into(%{})
 
     query = %Boltx.Query{statement: statement, extra: extra}
 

--- a/lib/boltx.ex
+++ b/lib/boltx.ex
@@ -106,7 +106,9 @@ defmodule Boltx do
       |> Enum.map(fn {k, {:ok, value}} -> {k, value} end)
       |> Map.new()
 
-    query = %Boltx.Query{statement: statement}
+    extra = Map.take(opts, [:bookmarks, :mode, :db, :tx_metadata])
+
+    query = %Boltx.Query{statement: statement, extra: extra}
     do_query(conn, query, formatted_params, opts)
   end
 


### PR DESCRIPTION
The previous version didn't have a way (that I saw) to utilize the "extras" portion of the Query struct. 

I updated the `query` function at the root level to look for the specific `extra` related keys in the opts list and construct the extra portion of the Query. 

This was important because I didn't have a way to switch to non-default database.

I also put a few docs in about usage.