### PR TITLE
fix: always send RESET after query errors to prevent connection poisoning

### DIFF
--- a/lib/boltx/client.ex
+++ b/lib/boltx/client.ex
@@ -235,7 +235,7 @@ defmodule Boltx.Client do
          encode_version <- recv_packets(client, config.connect_timeout),
          version <- decode_version(encode_version) do
       case version do
-        0.0 -> {:error, Boltx.Error.wrap(__MODULE__, :version_negotiation_error)}
+        +0.0 -> {:error, Boltx.Error.wrap(__MODULE__, :version_negotiation_error)}
         _ -> {:ok, %{client | bolt_version: version}}
       end
     else

--- a/lib/boltx/connection.ex
+++ b/lib/boltx/connection.ex
@@ -107,16 +107,14 @@ defmodule Boltx.Connection do
       {:ok, statement_result} ->
         {:ok, statement_result}
 
-      {:error, %Boltx.Error{code: error_code} = error} ->
-        action =
-          if client.bolt_version >= 3.0,
-            do: &Client.send_reset/1,
-            else: &Client.send_ack_failure/1
-
-        if error_code in [:syntax_error, :semantic_error] do
-          action.(client)
-        end
-
+      {:error, %Boltx.Error{} = error} ->
+        # Always send RESET after any error to clear the Neo4j connection's
+        # FAILED state.  The Bolt protocol requires this -- without it the
+        # connection enters a poisoned state where subsequent queries receive
+        # IGNORED responses.  The original code only reset for :syntax_error
+        # and :semantic_error, leaving constraint-violation and other errors
+        # to poison the connection pool.
+        reset_after_failure(client)
         {:error, error, state}
     end
   rescue
@@ -124,7 +122,17 @@ defmodule Boltx.Connection do
       {:error, %{code: :failure, message: "#{e.message}, code: #{e.code}"}, state}
 
     e ->
-      {:error, %{code: :failure, message: e}}
+      {:error, %{code: :failure, message: e}, state}
+  end
+
+  defp reset_after_failure(client) do
+    if client.bolt_version >= 3.0,
+      do: Client.send_reset(client),
+      else: Client.send_ack_failure(client)
+  rescue
+    # If the reset itself fails, the connection is truly broken and
+    # DBConnection will discard it on the next health-check.
+    _ -> :ok
   end
 
   defp result(

--- a/lib/boltx/connection.ex
+++ b/lib/boltx/connection.ex
@@ -119,7 +119,7 @@ defmodule Boltx.Connection do
     end
   rescue
     e in Boltx.Error ->
-      {:error, %{code: :failure, message: "#{e.message}, code: #{e.code}"}, state}
+      {:error, %{code: :failure, message: Exception.message(e)}, state}
 
     e ->
       {:error, %{code: :failure, message: e}, state}


### PR DESCRIPTION
The Bolt protocol requires a RESET after any FAILURE response to clear the error state.  Previously only :syntax_error and :semantic_error triggered a RESET, leaving constraint-violation and other errors to poison the connection -- subsequent queries on the same connection received IGNORED responses and crashed with CaseClauseError.

Also fixes the rescue clause to include state in the error tuple, preventing KeyError on disconnect.

Also fixes https://github.com/sagastume/boltx/issues/140